### PR TITLE
Fix 500s on "not a directory" errors and "multiple response.WriteHeader calls" on 404s

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,8 +69,6 @@ func FileServer(fs http.FileSystem, errorPage string) http.Handler {
 }
 
 func NotFound(fs http.FileSystem, w http.ResponseWriter, r *http.Request, errorPage string) {
-	w.WriteHeader(404)
-	w.Header().Set("Content-Type", "text/html")
 	WriteFile(fs, w, r, errorPage)
 }
 

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func FileServer(fs http.FileSystem, errorPage string) http.Handler {
 	fsh := http.FileServer(fs)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := fs.Open(path.Clean(r.URL.Path))
-		if os.IsNotExist(err) {
+		if err != nil && !os.IsPermission(err) {
 			fmt.Println("Not found: " + r.URL.Path)
 			NotFound(fs, w, r, errorPage)
 			return


### PR DESCRIPTION
If you serve a directory, and try to access a file but append a slash followed by some chars, the server returns a 500. E.g.

```
go run main.go .
```

http://localhost:3000/main.go will 200
http://localhost:3000/main.go/foobar will 500

The error being returned is from the call to `fs.Open`:
```
open main.go/foobar: not a directory
```

After this PR, http://localhost:3000/main.go/foobar will 404

Furthermore, this PR fixes the warnings on 404s:
```
multiple response.WriteHeader calls
```


cc @segmentio/gateway 